### PR TITLE
fix linker error (undefined reference to symbol 'pthread_create@@GLIBC_2...

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,7 +31,7 @@ webradio_SOURCES = main.cxx \
 	dsp/downconverter.cxx \
 	dsp/demodulator.cxx
 
-webradio_LDADD = -lm -lmp3lame \
+webradio_LDADD = -lm -lmp3lame -lpthread \
 	$(libmicrohttpd_LIBS) \
 	$(libfftw3_LIBS) \
 	$(librtlsdr_LIBS) \


### PR DESCRIPTION
Got this while compiling:
/usr/bin/ld: io/rtlsdrtuner.o: undefined reference to symbol 'pthread_create@@GLIBC_2.1'

Fixed by adding -lpthread to Makefile.am

System is: 
Linux Mint 17 MATE 32-bit
Linux 3.13.0-24-generic #47-Ubuntu SMP Fri May 2 23:31:42 UTC 2014 i686 

Also tested on Linux Mint 16 MATE 32-bit.
